### PR TITLE
Rotation did not properly reset

### DIFF
--- a/eurofurence/AppDelegate.swift
+++ b/eurofurence/AppDelegate.swift
@@ -61,6 +61,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
+        if UIDevice.currentDevice().orientation != .Portrait {
+            UIDevice.currentDevice().setValue(UIInterfaceOrientation.Portrait.rawValue, forKey: "orientation")
+        }
+        
         // Only allow portrait (standard behaviour)
         return .Portrait;
     }

--- a/eurofurence/DealerTableViewController.swift
+++ b/eurofurence/DealerTableViewController.swift
@@ -20,6 +20,10 @@ class DealerTableViewController: UITableViewController {
         self.refreshControl?.addTarget(self, action: #selector(DealerTableViewController.refresh(_:)), forControlEvents: UIControlEvents.ValueChanged)
     }
     
+    func canRotate()->Bool {
+        return true
+    }
+    
     // Pull to refresh function
     func refresh(sender:AnyObject) {
         ApiManager.sharedInstance.updateAllEntities(false, completion: {(isDataUpdated: Bool) in


### PR DESCRIPTION
When switching from a view with rotation support to one without while not in portrait mode, the device would retain its rotation, potentially breaking the layout of views without rotation support.
This hotfix forces the device to switch back to portrait if the next view doesn't support rotation.
